### PR TITLE
Port code from 43276

### DIFF
--- a/csrc/moe/fp32_router_gemm.cu
+++ b/csrc/moe/fp32_router_gemm.cu
@@ -104,7 +104,6 @@ __global__ __launch_bounds__(128, 1) void fp32_router_gemm_kernel(
   }
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-  asm volatile("griddepcontrol.launch_dependents;");
   asm volatile("griddepcontrol.wait;");
 #endif
 
@@ -149,6 +148,11 @@ __global__ __launch_bounds__(128, 1) void fp32_router_gemm_kernel(
       out[m * kNumExperts + n_idx] = final_sum;
     }
   }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  __syncthreads();
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
 }
 
 // ---------------------------------------------------------------------------
@@ -166,7 +170,7 @@ void invokeFp32RouterGemm(float* output, InputT const* mat_a,
   config.stream = stream;
   cudaLaunchAttribute attrs[1];
   attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-  attrs[0].val.programmaticStreamSerializationAllowed = 1;
+  attrs[0].val.programmaticStreamSerializationAllowed = getEnvEnablePDL();
   config.numAttrs = 1;
   config.attrs = attrs;
   cudaLaunchKernelEx(&config,

--- a/csrc/moe/fp32_router_gemm.cu
+++ b/csrc/moe/fp32_router_gemm.cu
@@ -78,7 +78,7 @@ __device__ __forceinline__ void load_activation<__nv_bfloat16, 8>(
 // Weight is always fp32; output is always fp32.
 // VPT = 16 / sizeof(InputT):  4 for fp32, 8 for bf16
 template <typename InputT, int kBlockSize, int kNumTokens, int kNumExperts,
-          int kHiddenDim>
+          int kHiddenDim, bool ENABLE_PDL>
 __global__ __launch_bounds__(128, 1) void fp32_router_gemm_kernel(
     float* out, InputT const* mat_a, float const* mat_b) {
   constexpr int VPT = 16 / sizeof(InputT);
@@ -103,8 +103,11 @@ __global__ __launch_bounds__(128, 1) void fp32_router_gemm_kernel(
     k_bases[ki] = ki * k_elems_per_k_iteration + tid * VPT;
   }
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-  asm volatile("griddepcontrol.wait;");
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12000) && \
+    defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  if constexpr (ENABLE_PDL) {
+    asm volatile("griddepcontrol.wait;");
+  }
 #endif
 
   for (int ki = 0; ki < k_iterations; ki++) {
@@ -149,9 +152,12 @@ __global__ __launch_bounds__(128, 1) void fp32_router_gemm_kernel(
     }
   }
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-  __syncthreads();
-  asm volatile("griddepcontrol.launch_dependents;");
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12000) && \
+    defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  if constexpr (ENABLE_PDL) {
+    __syncthreads();
+    asm volatile("griddepcontrol.launch_dependents;");
+  }
 #endif
 }
 
@@ -163,20 +169,29 @@ template <typename InputT, int kNumTokens, int kNumExperts, int kHiddenDim>
 void invokeFp32RouterGemm(float* output, InputT const* mat_a,
                           float const* mat_b, cudaStream_t stream) {
   constexpr int kBlockSize = 128;
-  cudaLaunchConfig_t config;
-  config.gridDim = kNumExperts;
-  config.blockDim = kBlockSize;
-  config.dynamicSmemBytes = 0;
-  config.stream = stream;
-  cudaLaunchAttribute attrs[1];
-  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-  attrs[0].val.programmaticStreamSerializationAllowed = getEnvEnablePDL();
-  config.numAttrs = 1;
-  config.attrs = attrs;
-  cudaLaunchKernelEx(&config,
-                     fp32_router_gemm_kernel<InputT, kBlockSize, kNumTokens,
-                                             kNumExperts, kHiddenDim>,
-                     output, mat_a, mat_b);
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12000)
+  if (getEnvEnablePDL()) {
+    cudaLaunchConfig_t config;
+    config.gridDim = kNumExperts;
+    config.blockDim = kBlockSize;
+    config.dynamicSmemBytes = 0;
+    config.stream = stream;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = 1;
+    config.numAttrs = 1;
+    config.attrs = attrs;
+    cudaLaunchKernelEx(&config,
+                       fp32_router_gemm_kernel<InputT, kBlockSize, kNumTokens,
+                                               kNumExperts, kHiddenDim, true>,
+                       output, mat_a, mat_b);
+    return;
+  }
+#endif
+
+  fp32_router_gemm_kernel<InputT, kBlockSize, kNumTokens, kNumExperts,
+                          kHiddenDim, false>
+      <<<kNumExperts, kBlockSize, 0, stream>>>(output, mat_a, mat_b);
 }
 
 // ---------------------------------------------------------------------------

--- a/csrc/moe/fp32_router_gemm_entry.cu
+++ b/csrc/moe/fp32_router_gemm_entry.cu
@@ -3,6 +3,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <torch/all.h>
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
@@ -54,11 +55,24 @@ void fp32_router_gemm(at::Tensor& output,       // [num_tokens, num_experts]
                       const at::Tensor& mat_b   // [num_experts, hidden_dim]
 ) {
   TORCH_CHECK(output.dim() == 2 && mat_a.dim() == 2 && mat_b.dim() == 2);
+  TORCH_CHECK(output.is_cuda() && mat_a.is_cuda() && mat_b.is_cuda(),
+              "fp32_router_gemm: all tensors must be CUDA tensors");
+  TORCH_CHECK(output.get_device() == mat_a.get_device() &&
+                  output.get_device() == mat_b.get_device(),
+              "fp32_router_gemm: all tensors must be on the same CUDA device");
+  TORCH_CHECK(output.is_contiguous() && mat_a.is_contiguous() &&
+                  mat_b.is_contiguous(),
+              "fp32_router_gemm: all tensors must be contiguous");
 
   const int num_tokens = mat_a.size(0);
   const int num_experts = mat_b.size(0);
   const int hidden_dim = mat_a.size(1);
 
+  TORCH_CHECK(output.size(0) == num_tokens && output.size(1) == num_experts,
+              "fp32_router_gemm: output must have shape [num_tokens, "
+              "num_experts], got [",
+              output.size(0), ", ", output.size(1), "], expected [",
+              num_tokens, ", ", num_experts, "]");
   TORCH_CHECK(
       mat_a.size(1) == mat_b.size(1),
       "fp32_router_gemm: mat_a and mat_b must have the same hidden_dim");
@@ -68,8 +82,8 @@ void fp32_router_gemm(at::Tensor& output,       // [num_tokens, num_experts]
   TORCH_CHECK(num_experts == FP32_NUM_EXPERTS,
               "fp32_router_gemm: expected num_experts=", FP32_NUM_EXPERTS,
               ", got ", num_experts);
-  TORCH_CHECK(num_tokens >= 1 && num_tokens <= FP32_MAX_TOKENS,
-              "fp32_router_gemm: num_tokens must be in [1, ", FP32_MAX_TOKENS,
+  TORCH_CHECK(num_tokens <= FP32_MAX_TOKENS,
+              "fp32_router_gemm: num_tokens must be in [0, ", FP32_MAX_TOKENS,
               "], got ", num_tokens);
   TORCH_CHECK(mat_a.dtype() == at::kFloat || mat_a.dtype() == at::kBFloat16,
               "fp32_router_gemm: mat_a must be float32 or bfloat16");
@@ -78,6 +92,11 @@ void fp32_router_gemm(at::Tensor& output,       // [num_tokens, num_experts]
   TORCH_CHECK(output.dtype() == at::kFloat,
               "fp32_router_gemm: output must be float32");
 
+  if (num_tokens == 0) {
+    return;
+  }
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(mat_a));
   const int sm = getSMVersion();
   TORCH_CHECK(sm >= 90, "fp32_router_gemm: requires SM90+, got SM", sm);
 

--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -315,9 +315,9 @@ __launch_bounds__(WARPS_PER_CTA* WARP_SIZE_PARAM) __global__
     const int thread_row = warp_base_row + thread_row_in_warp;
 
 
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && (CUDA_VERSION >= 12000) && \
+    defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
     if constexpr (ENABLE_PDL) {
-        asm volatile("griddepcontrol.launch_dependents;");
         asm volatile("griddepcontrol.wait;");
     }
 #endif
@@ -569,6 +569,13 @@ __launch_bounds__(WARPS_PER_CTA* WARP_SIZE_PARAM) __global__
         }
     }
 
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && (CUDA_VERSION >= 12000) && \
+    defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+    if constexpr (ENABLE_PDL) {
+        asm volatile("griddepcontrol.launch_dependents;");
+    }
+#endif
+
 }
 
 namespace detail
@@ -599,7 +606,7 @@ void topkGatingLauncherHelper(const InputType* input, const bool* finished, floa
     const int num_blocks = (num_warps + WARPS_PER_TB - 1) / WARPS_PER_TB;
 
     dim3 block_dim(WARP_SIZE_PARAM, WARPS_PER_TB);
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && (CUDA_VERSION >= 12000)
     if (enable_pdl) {
         cudaLaunchConfig_t config;
         config.gridDim = num_blocks;

--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -62,6 +62,13 @@ __device__ __forceinline__ float toFloat(T value) {
     }
 }
 
+#ifndef USE_ROCM
+inline bool supportsPdlOnCurrentDevice() {
+    const auto* props = at::cuda::getCurrentDeviceProperties();
+    return props != nullptr && props->major >= 9;
+}
+#endif
+
 // Scoring function enums
 enum ScoringFunc {
   SCORING_SOFTMAX = 0, // apply softmax
@@ -607,7 +614,7 @@ void topkGatingLauncherHelper(const InputType* input, const bool* finished, floa
 
     dim3 block_dim(WARP_SIZE_PARAM, WARPS_PER_TB);
 #if !defined(USE_ROCM) && defined(CUDA_VERSION) && (CUDA_VERSION >= 12000)
-    if (enable_pdl) {
+    if (enable_pdl && supportsPdlOnCurrentDevice()) {
         cudaLaunchConfig_t config;
         config.gridDim = num_blocks;
         config.blockDim = block_dim;

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2300,6 +2300,17 @@ def gpt_oss_router_gemm(
     return output
 
 
+if hasattr(torch.ops, "_moe_C") and hasattr(torch.ops._moe_C, "fp32_router_gemm"):
+
+    @register_fake("_moe_C::fp32_router_gemm")
+    def fp32_router_gemm_fake(
+        output: torch.Tensor,
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+    ) -> None:
+        return
+
+
 def topk_softmax(
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
     VLLM_MAIN_CUDA_VERSION: str = "12.9"
     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
     VLLM_BATCH_INVARIANT: bool = False
+    TRTLLM_ENABLE_PDL: bool = False
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
     VLLM_USE_PRECOMPILED: bool = False
@@ -500,6 +501,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable batch-invariant mode: deterministic results regardless of
     # batch composition. Requires NVIDIA GPU with compute capability >= 9.0.
     "VLLM_BATCH_INVARIANT": lambda: bool(int(os.getenv("VLLM_BATCH_INVARIANT", "0"))),
+    # Enable Programmatic Dependent Launch for supported NVIDIA MoE router
+    # kernels. Requires CUDA >= 12.0 and compute capability >= 9.0.
+    "TRTLLM_ENABLE_PDL": lambda: bool(int(os.getenv("TRTLLM_ENABLE_PDL", "0"))),
     # Maximum number of compilation jobs to run in parallel.
     # By default this is the number of CPUs
     "MAX_JOBS": lambda: os.getenv("MAX_JOBS", None),

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -233,6 +233,8 @@ class FusedMoE(CustomOp):
         quant_config: Quantization configure.
         enable_eplb: Whether to enable expert parallelism load balancer.
         router_logits_dtype: Data type for router logits buffers.
+        enable_router_pdl: Whether fused top-k routing kernels should join a
+                           Programmatic Dependent Launch chain.
     """
 
     # --8<-- [end:fused_moe]
@@ -272,6 +274,7 @@ class FusedMoE(CustomOp):
         gate: torch.nn.Module | None = None,
         shared_experts: torch.nn.Module | None = None,
         routed_input_transform: torch.nn.Module | None = None,
+        enable_router_pdl: bool = False,
     ):
         super().__init__()
 
@@ -462,6 +465,7 @@ class FusedMoE(CustomOp):
             # TODO(bnell): once we can construct the MK at init time, we
             # can make this a value.
             indices_type_getter=lambda: self.quant_method.topk_indices_dtype,
+            enable_pdl=enable_router_pdl,
         )
         self.routing_method_type: RoutingMethodType = self.router.routing_method_type
 

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -45,7 +45,7 @@ def vllm_topk_sigmoid(
     gating_output: torch.Tensor,
     renormalize: bool = False,
     e_score_correction_bias: torch.Tensor | None = None,
-    enable_pdl: bool = True,  # FIXME
+    enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, ...]:
     ops.topk_sigmoid(
         topk_weights,
@@ -81,6 +81,7 @@ def fused_topk_bias(
     renormalize: bool,
     scoring_func: str = "softmax",
     indices_type: torch.dtype | None = None,
+    enable_pdl: bool = False,
 ):
     if not rocm_aiter_ops.is_fused_moe_enabled():
         assert hidden_states.size(0) == gating_output.size(0), (
@@ -110,6 +111,7 @@ def fused_topk_bias(
                 gating_output,
                 renormalize,
                 e_score_correction_bias,
+                enable_pdl,
             )
             return topk_weights, topk_ids
         elif scoring_func == "sigmoid":
@@ -120,6 +122,7 @@ def fused_topk_bias(
                 gating_output,
                 renormalize,
                 e_score_correction_bias,
+                enable_pdl,
             )
             return topk_weights, topk_ids
         else:
@@ -186,6 +189,7 @@ class FusedTopKBiasRouter(BaseRouter):
         routed_scaling_factor: float = 1.0,
         enable_eplb: bool = False,
         indices_type_getter: Callable[[], torch.dtype | None] | None = None,
+        enable_pdl: bool = False,
     ):
         super().__init__(
             top_k=top_k,
@@ -198,6 +202,7 @@ class FusedTopKBiasRouter(BaseRouter):
         self.renormalize = renormalize
         self.scoring_func = scoring_func
         self.routed_scaling_factor = routed_scaling_factor
+        self.enable_pdl = enable_pdl
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
@@ -224,6 +229,7 @@ class FusedTopKBiasRouter(BaseRouter):
             renormalize=self.renormalize,
             scoring_func=self.scoring_func,
             indices_type=indices_type,
+            enable_pdl=self.enable_pdl,
         )
 
         if self.routed_scaling_factor != 1.0:

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -77,6 +77,7 @@ def fused_topk(
     renormalize: bool,
     indices_type: torch.dtype | None = None,
     scoring_func: str = "softmax",
+    enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert hidden_states.size(0) == gating_output.size(0), "Number of tokens mismatch"
 
@@ -96,20 +97,30 @@ def fused_topk(
     )
 
     if scoring_func == "softmax":
-        topk_func = dispatch_topk_softmax_func(
-            use_rocm_aiter=rocm_aiter_ops.is_fused_moe_enabled()
-        )
+        use_rocm_aiter = rocm_aiter_ops.is_fused_moe_enabled()
+        topk_func = dispatch_topk_softmax_func(use_rocm_aiter=use_rocm_aiter)
+        pdl_kwargs = {} if use_rocm_aiter else {"enable_pdl": enable_pdl}
         topk_weights, topk_ids = topk_func(
-            topk_weights, topk_ids, token_expert_indices, gating_output, renormalize
+            topk_weights,
+            topk_ids,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            **pdl_kwargs,
         )
 
         return topk_weights, topk_ids, token_expert_indices
     elif scoring_func == "sigmoid":
-        topk_func = dispatch_topk_sigmoid_func(
-            use_rocm_aiter=rocm_aiter_ops.is_fused_moe_enabled()
-        )
+        use_rocm_aiter = rocm_aiter_ops.is_fused_moe_enabled()
+        topk_func = dispatch_topk_sigmoid_func(use_rocm_aiter=use_rocm_aiter)
+        pdl_kwargs = {} if use_rocm_aiter else {"enable_pdl": enable_pdl}
         topk_weights, topk_ids = topk_func(
-            topk_weights, topk_ids, token_expert_indices, gating_output, renormalize
+            topk_weights,
+            topk_ids,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            **pdl_kwargs,
         )
 
         return topk_weights, topk_ids, token_expert_indices
@@ -129,6 +140,7 @@ class FusedTopKRouter(BaseRouter):
         renormalize: bool = True,
         enable_eplb: bool = False,
         indices_type_getter: Callable[[], torch.dtype | None] | None = None,
+        enable_pdl: bool = False,
     ):
         super().__init__(
             top_k=top_k,
@@ -139,6 +151,7 @@ class FusedTopKRouter(BaseRouter):
         )
         self.renormalize = renormalize
         self.scoring_func = scoring_func
+        self.enable_pdl = enable_pdl
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
@@ -164,6 +177,7 @@ class FusedTopKRouter(BaseRouter):
             renormalize=self.renormalize,
             indices_type=indices_type,
             scoring_func=self.scoring_func,
+            enable_pdl=self.enable_pdl,
         )
 
         return topk_weights, topk_ids

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -175,6 +175,8 @@ def fp32_router_gemm_dispatch_impl(
     This must be wrapped in a custom op because our torch.compile integration
     does not support runtime dispatching on num_tokens.
     """
+    x = x.contiguous()
+    weight = weight.contiguous()
     if x.shape[0] <= _FP32_ROUTER_GEMM_MAX_TOKENS:
         return ops.fp32_router_gemm(x, weight)
     else:

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -15,7 +15,8 @@ class GateLinear(ReplicatedLinear):
     """MoE gate linear layer with multi-tier GEMM dispatch:
 
     1. DSV3 specialized kernel (SM90+, fp32 out, M<=16, H=7168, E=256/384)
-    2. fp32 specialized kernel  (SM90+, fp32 in/out, M<=32, H=3072, E=256)
+    2. fp32 specialized kernel  (SM90+, bf16/fp32 in, fp32 out,
+       M<=32, H=3072, E=256)
     3. gpt-oss specialized kernel (SM90+, bf16, M<=128, H=2880, E=32/128)
     4. cuBLAS bf16×bf16→fp32 (SM90+ + bf16 weight + fp32 out_dtype)
     5. F.linear via ReplicatedLinear (ultimate fallback)
@@ -56,7 +57,7 @@ class GateLinear(ReplicatedLinear):
         )
 
         # If fp32 compute is required and no specialized kernel is available,
-        # store weights in fp32 so Tier 3 computes in fp32 natively.
+        # store weights in fp32 so the fallback linear path computes in fp32.
         if force_fp32_compute and not can_use_specialized_kernels:
             params_dtype = torch.float32
 
@@ -136,7 +137,10 @@ class GateLinear(ReplicatedLinear):
         # Tier 2: fp32 specialized kernel (H=3072, E=256, M<=32)
         # Dispatch is wrapped in a custom op so that torch.compile/CUDA-graph
         # capture does not freeze the runtime num_tokens branch.
-        if self.allow_fp32_router_gemm:
+        if self.allow_fp32_router_gemm and x.dtype in (
+            torch.float32,
+            torch.bfloat16,
+        ):
             output = torch.ops.vllm.fp32_router_gemm_dispatch(x, self.weight)
             return output, None
 

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -175,8 +175,6 @@ def fp32_router_gemm_dispatch_impl(
     This must be wrapped in a custom op because our torch.compile integration
     does not support runtime dispatching on num_tokens.
     """
-    x = x.contiguous()
-    weight = weight.contiguous()
     if x.shape[0] <= _FP32_ROUTER_GEMM_MAX_TOKENS:
         return ops.fp32_router_gemm(x, weight)
     else:

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -49,6 +49,7 @@ def create_fused_moe_router(
     # eplb parameters
     enable_eplb: bool = False,
     eplb_state: EplbLayerState = EMPTY_EPLB_STATE,
+    # routing kernel parameters
     enable_pdl: bool = False,
 ) -> FusedMoERouter:
     """
@@ -86,6 +87,8 @@ def create_fused_moe_router(
     EPLB arguments:
         enable_eplb: Whether EPLB is enabled
         eplb_state: EPLB (Expert Parallelism Load Balancing) state
+
+    Routing kernel arguments:
         enable_pdl: Whether CUDA fused top-k routing kernels should participate
             in a Programmatic Dependent Launch chain. This is only used on
             supported NVIDIA GPUs with CUDA >= 12.0 and SM90+.

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -86,6 +86,9 @@ def create_fused_moe_router(
     EPLB arguments:
         enable_eplb: Whether EPLB is enabled
         eplb_state: EPLB (Expert Parallelism Load Balancing) state
+        enable_pdl: Whether CUDA fused top-k routing kernels should participate
+            in a Programmatic Dependent Launch chain. This is only used on
+            supported NVIDIA GPUs with CUDA >= 12.0 and SM90+.
 
     Returns:
         An instance of the appropriate FusedMoERouter subclass

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -49,6 +49,7 @@ def create_fused_moe_router(
     # eplb parameters
     enable_eplb: bool = False,
     eplb_state: EplbLayerState = EMPTY_EPLB_STATE,
+    enable_pdl: bool = False,
 ) -> FusedMoERouter:
     """
     Factory function to create the appropriate FusedMoERouter subclass based on
@@ -156,6 +157,7 @@ def create_fused_moe_router(
             routed_scaling_factor=routed_scaling_factor,
             enable_eplb=enable_eplb,
             indices_type_getter=indices_type_getter,
+            enable_pdl=enable_pdl,
         )
 
     return FusedTopKRouter(
@@ -166,4 +168,5 @@ def create_fused_moe_router(
         scoring_func=scoring_func,
         enable_eplb=enable_eplb,
         indices_type_getter=indices_type_getter,
+        enable_pdl=enable_pdl,
     )

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -23,6 +23,7 @@
 # limitations under the License.
 """Inference-only MiniMaxM2 model."""
 
+import os
 from collections.abc import Iterable
 from typing import Any
 
@@ -57,6 +58,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
 from .interfaces import SupportsLoRA, SupportsPP
@@ -68,6 +70,17 @@ from .utils import (
     make_layers,
     maybe_prefix,
 )
+
+
+def _enable_router_pdl() -> bool:
+    is_hopper_or_blackwell = current_platform.is_device_capability(
+        (9, 0)
+    ) or current_platform.is_device_capability_family(100)
+    return (
+        current_platform.is_cuda()
+        and is_hopper_or_blackwell
+        and os.getenv("TRTLLM_ENABLE_PDL") == "1"
+    )
 
 
 class MiniMaxM2MoE(nn.Module):
@@ -108,6 +121,7 @@ class MiniMaxM2MoE(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.experts",
             router_logits_dtype=torch.float32,
+            enable_router_pdl=_enable_router_pdl(),
         )
 
         self.gate = GateLinear(

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -23,7 +23,6 @@
 # limitations under the License.
 """Inference-only MiniMaxM2 model."""
 
-import os
 from collections.abc import Iterable
 from typing import Any
 
@@ -31,6 +30,7 @@ import torch
 from torch import nn
 from transformers import PretrainedConfig
 
+import vllm.envs as envs
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.distributed import (
@@ -79,7 +79,7 @@ def _enable_router_pdl() -> bool:
     return (
         current_platform.is_cuda()
         and is_hopper_or_blackwell
-        and os.getenv("TRTLLM_ENABLE_PDL") == "1"
+        and envs.TRTLLM_ENABLE_PDL
     )
 
 


### PR DESCRIPTION
This ports the small follow-up fixes from [#43276](https://github.com/vllm-project/vllm/pull/43276) onto [`m2-gate-function`](https://github.com/vllm-project/vllm/pull/38445).

The CUDA changes are mostly ai-review-driven safety fixes. 
The Python changes complete the `enable_router_pdl` plumbing so MiniMax-M2 can opt into router PDL while keeping the default behavior unchanged.

### H800

```
CUDA_VISIBLE_DEVICES=0 python3 - <<'PY'
import torch
import torch.nn.functional as F
from vllm import _custom_ops as ops

torch.manual_seed(0)
H, E = 3072, 256

for precision, matmul_precision in [("default", None), ("fp32_high", "high")]:
    if matmul_precision is not None:
        torch.set_float32_matmul_precision(matmul_precision)
    else:
        torch.set_float32_matmul_precision("highest")

    for dtype, atol in [(torch.bfloat16, 2e-2), (torch.float32, 2e-4)]:
        for M in [1, 2, 3, 4, 7, 8, 15, 16, 31, 32]:
            x = torch.randn(M, H, device="cuda", dtype=dtype).contiguous()
            w = torch.randn(E, H, device="cuda", dtype=torch.float32).contiguous()
            out = ops.fp32_router_gemm(x, w)
            ref = F.linear(x.float(), w)
            err = (out - ref).abs()
            print(f"prec={precision} {dtype} M={M}",
                  "max_abs=", err.max().item(),
                  "mean_abs=", err.mean().item(),
                  "pass=", bool(torch.allclose(out, ref, atol=atol, rtol=0)))
PY
```
```
prec=default torch.bfloat16 M=1 max_abs= 3.814697265625e-05 mean_abs= 9.896233677864075e-06 pass= True
prec=default torch.bfloat16 M=2 max_abs= 6.103515625e-05 mean_abs= 1.0900897905230522e-05 pass= True
prec=default torch.bfloat16 M=3 max_abs= 4.673004150390625e-05 mean_abs= 1.0053938240162097e-05 pass= True
prec=default torch.bfloat16 M=4 max_abs= 3.814697265625e-05 mean_abs= 1.0253861546516418e-05 pass= True
prec=default torch.bfloat16 M=7 max_abs= 6.103515625e-05 mean_abs= 1.2296851309656631e-05 pass= True
prec=default torch.bfloat16 M=8 max_abs= 5.340576171875e-05 mean_abs= 1.2036529369652271e-05 pass= True
prec=default torch.bfloat16 M=15 max_abs= 5.53131103515625e-05 mean_abs= 1.2322170732659288e-05 pass= True
prec=default torch.bfloat16 M=16 max_abs= 6.103515625e-05 mean_abs= 1.2327080185059458e-05 pass= True
prec=default torch.bfloat16 M=31 max_abs= 6.103515625e-05 mean_abs= 9.407965080754366e-06 pass= True
prec=default torch.bfloat16 M=32 max_abs= 6.103515625e-05 mean_abs= 9.411050996277481e-06 pass= True
prec=default torch.float32 M=1 max_abs= 3.0517578125e-05 mean_abs= 8.818693459033966e-06 pass= True
prec=default torch.float32 M=2 max_abs= 4.57763671875e-05 mean_abs= 9.83034260571003e-06 pass= True
prec=default torch.float32 M=3 max_abs= 4.57763671875e-05 mean_abs= 9.48490014707204e-06 pass= True
prec=default torch.float32 M=4 max_abs= 5.340576171875e-05 mean_abs= 9.826384484767914e-06 pass= True
prec=default torch.float32 M=7 max_abs= 5.7220458984375e-05 mean_abs= 1.2004881682514679e-05 pass= True
prec=default torch.float32 M=8 max_abs= 5.340576171875e-05 mean_abs= 1.2546559446491301e-05 pass= True
prec=default torch.float32 M=15 max_abs= 6.103515625e-05 mean_abs= 1.2333870472502895e-05 pass= True
prec=default torch.float32 M=16 max_abs= 7.62939453125e-05 mean_abs= 1.221662387251854e-05 pass= True
prec=default torch.float32 M=31 max_abs= 7.62939453125e-05 mean_abs= 9.509156370768324e-06 pass= True
prec=default torch.float32 M=32 max_abs= 7.62939453125e-05 mean_abs= 9.350329492008314e-06 pass= True
prec=fp32_high torch.bfloat16 M=1 max_abs= 3.0517578125e-05 mean_abs= 8.903443813323975e-06 pass= True
prec=fp32_high torch.bfloat16 M=2 max_abs= 0.044440269470214844 mean_abs= 0.009015086106956005 pass= False
prec=fp32_high torch.bfloat16 M=3 max_abs= 0.0346832275390625 mean_abs= 0.008942199870944023 pass= False
prec=fp32_high torch.bfloat16 M=4 max_abs= 0.04113006591796875 mean_abs= 0.009151562117040157 pass= False
prec=fp32_high torch.bfloat16 M=7 max_abs= 0.04279804229736328 mean_abs= 0.008998721837997437 pass= False
prec=fp32_high torch.bfloat16 M=8 max_abs= 0.0445556640625 mean_abs= 0.009134004823863506 pass= False
prec=fp32_high torch.bfloat16 M=15 max_abs= 0.03853607177734375 mean_abs= 0.009143132716417313 pass= False
prec=fp32_high torch.bfloat16 M=16 max_abs= 0.04340171813964844 mean_abs= 0.00932237133383751 pass= False
prec=fp32_high torch.bfloat16 M=31 max_abs= 0.04761219024658203 mean_abs= 0.009131493046879768 pass= False
prec=fp32_high torch.bfloat16 M=32 max_abs= 0.04586029052734375 mean_abs= 0.009119704365730286 pass= False
prec=fp32_high torch.float32 M=1 max_abs= 3.4332275390625e-05 mean_abs= 8.806586265563965e-06 pass= True
prec=fp32_high torch.float32 M=2 max_abs= 0.05176544189453125 mean_abs= 0.013077953830361366 pass= False
prec=fp32_high torch.float32 M=3 max_abs= 0.051513671875 mean_abs= 0.01334131509065628 pass= False
prec=fp32_high torch.float32 M=4 max_abs= 0.05275726318359375 mean_abs= 0.013239540159702301 pass= False
prec=fp32_high torch.float32 M=7 max_abs= 0.06198310852050781 mean_abs= 0.013133209198713303 pass= False
prec=fp32_high torch.float32 M=8 max_abs= 0.06512451171875 mean_abs= 0.013000346720218658 pass= False
prec=fp32_high torch.float32 M=15 max_abs= 0.06135368347167969 mean_abs= 0.013118076138198376 pass= False
prec=fp32_high torch.float32 M=16 max_abs= 0.061614990234375 mean_abs= 0.012958699837327003 pass= False
prec=fp32_high torch.float32 M=31 max_abs= 0.06546783447265625 mean_abs= 0.012923624366521835 pass= False
prec=fp32_high torch.float32 M=32 max_abs= 0.07131576538085938 mean_abs= 0.012893503531813622 pass= False
```




```
CUDA_VISIBLE_DEVICES=0 TRTLLM_ENABLE_PDL=0 \
python3 benchmarks/kernels/benchmark_router_gemm.py \
  --model MiniMaxAI/MiniMax-M2.7 \
  --max-batch-size 32 \
  --trust-remote-code

CUDA_VISIBLE_DEVICES=0 TRTLLM_ENABLE_PDL=1 \
python3 benchmarks/kernels/benchmark_router_gemm.py \
  --model MiniMaxAI/MiniMax-M2.7 \
  --max-batch-size 32 \
  --trust-remote-code
```

```
MiniMaxAI/MiniMax-M2.7 router gemm throughput:
   batch_size  PyTorch (TFLOPs)  vLLM (TFLOPs)
0         1.0          0.311737       0.761627
1         2.0          0.263098       1.422127
2         4.0          0.523085       2.584606
3         8.0          0.784099       4.342279
4        16.0          1.513443       6.493178
5        32.0          3.489885       7.984414
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
MiniMaxAI/MiniMax-M2.7 router gemm throughput:
   batch_size  PyTorch (TFLOPs)  vLLM (TFLOPs)
0         1.0          0.311601       0.916041
1         2.0          0.263055       1.716123
2         4.0          0.523220       3.037290
3         8.0          0.783896       4.967528
4        16.0          1.513612       7.038150
5        32.0          3.495769       8.374800
```